### PR TITLE
PNP-12364 Fixed exception when rendering controller from template

### DIFF
--- a/Profiler/Matcher/RequestMatcher.php
+++ b/Profiler/Matcher/RequestMatcher.php
@@ -43,8 +43,15 @@ class RequestMatcher implements RequestMatcherInterface
 
     public function matches(Request $request)
     {
-        $route = $this->router->matchRequest($request);
-        $routeName = $route['_route'];
+        // If we already have _controller attribute in request, there is no need to match it with router.
+        // This is most probably sub-request and it may not even have route to match
+        if ($request->attributes->get('_controller')) {
+            $route['_controller'] = $request->attributes->get('_controller');
+            $routeName = $request->attributes->get('_controller');
+        } else {
+            $route = $this->router->matchRequest($request);
+            $routeName = $route['_route'];
+        }
 
         $cache = $this->getCache($routeName);
         if (is_bool($cache)) {


### PR DESCRIPTION
{{ render(controller('foo') }} uses path like '/_fragment' which is handled by fragment listener and should never be matched by router (it will always fail, there is no route for '/_fragment'). In those cases we already have controller in request attributes, so we don't even need to match request with router.